### PR TITLE
fix(config): invert default square colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ The resulting PNG's will be 1200px by 1200px.
 
 | Option | Type     | Default | Example          |
 |----------|----------|---------|------------------|
-| light     | `string` | *"rgb(181, 136, 99)"* | *"rgb(250,250,250)", "white", "#ffffff"* |
+| light     | `string` | *"rgb(240, 217, 181)"* | *"rgb(250,250,250)", "white", "#ffffff"* |
 | dark     | `string` | *"rgb(181, 136, 99)"* | *"rgb(0,0,0)", "black", "#000000"* |
 
 Light and dark determines the colors of both the light and dark squares respectively.

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,9 +6,9 @@ const black = 'pbnrqk';
 
 const defaultSize = 480;
 
-const defaultLight = 'rgb(181, 136, 99)';
+const defaultLight = 'rgb(240, 217, 181)';
 
-const defaultDark = 'rgb(240, 217, 181)';
+const defaultDark = 'rgb(181, 136, 99)';
 
 const deafultStyle = 'merida';
 


### PR DESCRIPTION
## Summary
Using the default config to load a FEN string, a friend pointed out that the queens don't start on their own color 😅 

![queens](https://user-images.githubusercontent.com/4765455/111943697-54fff280-8aac-11eb-9133-c978838c114e.png)

After looking into the source code I noticed the default colors for Dark and Light are inverted.

![inverted](https://user-images.githubusercontent.com/4765455/111944215-7e6d4e00-8aad-11eb-92cf-1952210b4ba8.png)


This PR inverts the colors to (what I assume is) the intended default setup.

## Other Information
Thanks for this super helpful lib! 🙌  ♟️ 