### PR TITLE
(feature) added flipped option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Output to either:
     - [Canvas Size](#canvas-size)
     - [Board Colors](#board-colors)
     - [Piece Style](#piece-style)
+    - [Board POV](#board-pov)
 - [Dependencies](#dependencies)
 
 
@@ -62,7 +63,8 @@ var imageGenerator = new ChessImageGenerator({
     size: 720,
     light: 'rgb(200, 200, 200)',
     dark: '#333333',
-    style: 'merida'
+    style: 'merida',
+    flipped: true
 });
 ```
 
@@ -206,6 +208,7 @@ You have three options for customization of the resulting PNG:
 - [Canvas Size](#canvas-size)
 - [Board Colors](#board-colors)
 - [Piece Style](#piece-style)
+- [Board POV](#board-pov)
 
 These customizations are passed to the constructor when you create an instance of chess-image-generator:
 
@@ -214,7 +217,8 @@ var imageGenerator = new ChessImageGenerator({
     size: 720,
     light: 'rgb(200, 200, 200)',
     dark: '#333333',
-    style: 'merida'
+    style: 'merida',
+    flipped: true
 });
 ```
 
@@ -281,6 +285,16 @@ var imageGenerator = new ChessImageGenerator({
 | style     | *string* | *"merida"* | *"alpha", "cheq"* |
 
 The piece style determines the used style of pieces to create the image.
+
+
+# Board POV
+| Option  | Type      | Default | Example       |
+|---------|-----------|---------|---------------|
+| flipped | `boolean` | *false* | *true, false* |
+
+Determines if the board should be flipped.  
+If set to `false`, the image will be from white's point of view.
+If set to `true`, the image will be from black's point of view.  
 
 ## Style Choices:
 - alpha

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ var imageGenerator = new ChessImageGenerator({
 
 | Option | Type     | Default | Example          |
 |----------|----------|---------|------------------|
-| style     | *string* | *"merida""* | *"alpha", "cheq"* |
+| style     | *string* | *"merida"* | *"alpha", "cheq"* |
 
 The piece style determines the used style of pieces to create the image.
 

--- a/src/chess-image-generator.js
+++ b/src/chess-image-generator.js
@@ -14,7 +14,7 @@ const {
   defaultSize,
   defaultLight,
   defaultDark,
-  deafultStyle,
+  defaultStyle,
   filePaths,
 } = require('./config/index');
 
@@ -32,7 +32,7 @@ function ChessImageGenerator(options = {}) {
   this.size = options.size || defaultSize;
   this.light = options.light || defaultLight;
   this.dark = options.dark || defaultDark;
-  this.style = options.style || deafultStyle;
+  this.style = options.style || defaultStyle;
 
   this.ready = false;
 }

--- a/src/chess-image-generator.js
+++ b/src/chess-image-generator.js
@@ -25,6 +25,7 @@ const {
  * @param {string} light Color of light squares
  * @param {string} dark Color of dark squares
  * @param {style} style Desired style of pieces
+ * @param {boolean} flipped Sets desired board side
  */
 function ChessImageGenerator(options = {}) {
   this.chess = new Chess();
@@ -33,6 +34,7 @@ function ChessImageGenerator(options = {}) {
   this.light = options.light || defaultLight;
   this.dark = options.dark || defaultDark;
   this.style = options.style || defaultStyle;
+  this.flipped = options.flipped || false;
 
   this.ready = false;
 }
@@ -107,6 +109,9 @@ ChessImageGenerator.prototype = {
     ctx.fillStyle = this.light;
     ctx.fill();
 
+    const row = this.flipped ? r => r + 1 : r => 7 - r + 1;
+    const col = this.flipped ? c => c : c => 7 - c;
+
     for (let i = 0; i < 8; i += 1) {
       for (let j = 0; j < 8; j += 1) {
        
@@ -121,8 +126,8 @@ ChessImageGenerator.prototype = {
           ctx.fillStyle = this.dark;
           ctx.fill();
         }
-         
-        const piece = this.chess.get(cols[7 - j] + ((7 - i) + 1));
+
+        const piece = this.chess.get(cols[col(j)] + row(i));
          if (piece && piece.type !== '' && black.includes(piece.type.toLowerCase())) {
           const image = `resources/${this.style}/${filePaths[`${piece.color}${piece.type}`]}.png`;
           const imageFile = await loadImage(path.join(__dirname, image));

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -10,7 +10,7 @@ const defaultLight = 'rgb(240, 217, 181)';
 
 const defaultDark = 'rgb(181, 136, 99)';
 
-const deafultStyle = 'merida';
+const defaultStyle = 'merida';
 
 const filePaths = {
   wp: 'WhitePawn',
@@ -34,6 +34,6 @@ module.exports = {
   defaultSize,
   defaultLight,
   defaultDark,
-  deafultStyle,
+  defaultStyle,
   filePaths,
 };


### PR DESCRIPTION
## Summary
Adds `flipped` option to `ChessImageGenerator`. If `true`, the board image will appear from black's perspective. If `false` (default), the board will appear from white's perspective.