### PR TITLE
add support for highlighting squares

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Output to either:
     - [FEN](#loading-by-fen)
     - [PGN](#loading-by-pgn)
     - [Array of Characters](#loading-by-array)
+    - [Highlighting Squares](#highlighting-squares)
 - [Generating Images](#generate-an-image)
     - [into PNG](#generate-a-png)
     - [into Buffer](#generate-a-buffer)
@@ -168,6 +169,20 @@ Piece notation follows the same rules as [FEN](#loading-by-fen).
 | Uppercase Char | *White Pieces*          | *K, Q, R, B, N, P* |
 | Lowercase Char | *Black Pieces*          | *k, q, r, b, n, p* |
 
+# Highlighting Squares
+
+```
+.highlightSquares(array)
+```
+| Parameter    | Type     | Description          |
+|---------|----------|----------------------|
+| array | `array of strings` | Array of coordinates to highlight. |
+
+### Example:
+```
+imageGenerator.highlightSquares(["e4", "e5"])
+```
+
 # Generate an Image
 
 After you've loaded a chess position into an instance of the chess-image-generator, use the following functions to generate your image with one of two outputs:
@@ -263,8 +278,9 @@ The resulting PNG's will have a padding of 10px on each side, increasing the ima
 |----------|----------|---------|------------------|
 | light     | `string` | *"rgb(240, 217, 181)"* | *"rgb(250,250,250)", "white", "#ffffff"* |
 | dark     | `string` | *"rgb(181, 136, 99)"* | *"rgb(0,0,0)", "black", "#000000"* |
+| highlight | `string` | *"rgba(235, 97, 80, 0.8)"* | *"rgb(255,0,0)", "red", "#ff0000"* |
 
-Light and dark determines the colors of both the light and dark squares respectively.
+Light and dark determines the colors of both the light and dark squares respectively. Highlight determines the color overlaid on top of any highlighted squares (using a RGBA value with some transparency is recommended so that light and dark squares are still distinguishable from one another if highlighted).
 
 Colors can be passed in a variety of formats:
 

--- a/src/chess-image-generator.js
+++ b/src/chess-image-generator.js
@@ -12,6 +12,7 @@ const {
   defaultPadding,
   defaultLight,
   defaultDark,
+  defaultHighlight,
   defaultStyle,
   filePaths,
 } = require("./config/index");
@@ -21,6 +22,7 @@ const {
  * @property {number} [size] Pixel length of desired image
  * @property {string} [light] Color of light squares
  * @property {string} [dark] Color of dark squares
+ * @property {string} [highlight] Color of highlight overlay
  * @property {"merida"|"alpha"|"cheq"} [style] Desired style of pieces
  * @property {boolean} [flipped] Whether the board is to be flipped or not
  */
@@ -30,11 +32,13 @@ const {
  */
 function ChessImageGenerator(options = {}) {
   this.chess = new Chess();
+  this.highlightedSquares = [];
 
   this.size = options.size || defaultSize;
   this.padding = options.padding || defaultPadding;
   this.light = options.light || defaultLight;
   this.dark = options.dark || defaultDark;
+  this.highlight = options.highlight || defaultHighlight;
   this.style = options.style || defaultStyle;
   this.flipped = options.flipped || false;
 
@@ -90,6 +94,14 @@ ChessImageGenerator.prototype = {
   },
 
   /**
+   * Set which squares should be highlighted
+   * @param {string[]} array chess square coordinate array
+   */
+  highlightSquares(array) {
+    this.highlightedSquares = array;
+  },
+
+  /**
    * Generates buffer image based on position
    * @returns {Promise<Buffer>} Image buffer
    */
@@ -111,6 +123,8 @@ ChessImageGenerator.prototype = {
 
     for (let i = 0; i < 8; i += 1) {
       for (let j = 0; j < 8; j += 1) {
+        const coords = cols[col(j)] + row(i);
+
         if ((i + j) % 2 === 0) {
           ctx.beginPath();
           ctx.rect(
@@ -123,7 +137,20 @@ ChessImageGenerator.prototype = {
           ctx.fill();
         }
 
-        const piece = this.chess.get(cols[col(j)] + row(i));
+        if (this.highlightedSquares.includes(coords)) {
+          ctx.beginPath();
+          ctx.rect(
+            ((this.size / 8) * (7 - j + 1) - this.size / 8) + this.padding[3],
+            ((this.size / 8) * i) + this.padding[0],
+            this.size / 8,
+            this.size / 8
+          );
+          ctx.fillStyle = this.highlight;
+          ctx.fill();
+        }
+
+        const piece = this.chess.get(coords);
+
         if (
           piece &&
           piece.type !== "" &&

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -12,6 +12,8 @@ const defaultLight = 'rgb(240, 217, 181)';
 
 const defaultDark = 'rgb(181, 136, 99)';
 
+const defaultHighlight = 'rgba(235, 97, 80, 0.8)';
+
 const defaultStyle = 'merida';
 
 const filePaths = {
@@ -37,6 +39,7 @@ module.exports = {
   defaultPadding,
   defaultLight,
   defaultDark,
+  defaultHighlight,
   defaultStyle,
   filePaths,
 };


### PR DESCRIPTION
Adds the ability to highlight squares via `generator.highlightSquares()`. This is something I wanted for myself, both for highlighting the last move (a common feature in tactics puzzles) and for instructional positions where attention needs to be drawn to specific squares.

No worries if you don't want to merge this, but I figured I'd open a PR in case it seemed generally useful.

```javascript
const imageGenerator = new ChessImageGenerator();
const fen = "r1bqkbnr/pppp1ppp/2n5/4p3/3PP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 0 1";

imageGenerator.loadFEN(fen);
imageGenerator.highlightSquares(["e4", "e5"]);
imageGenerator.generatePNG("test.png");
```

![test](https://user-images.githubusercontent.com/29129/161336078-53f1c4fa-dff5-41ca-8a20-92a149e42451.png)
